### PR TITLE
building will not continue when pkgconfig script fails

### DIFF
--- a/mu/pkgconfig.sh
+++ b/mu/pkgconfig.sh
@@ -1,7 +1,15 @@
 set -e
 
+# args: value, expression
+add_config()
 {
-    echo "add cxxflags.mu $(pkg-config --cflags poppler-glib icu-uc)"
-    echo "add ldflags.svgtex $(pkg-config --libs poppler-glib)"
-    echo "add ldflags.mu $(pkg-config --libs icu-uc)"
+    if ! [ $# -eq 2 ]; then >&2 echo pkg-config script error; exit 1; fi
+    _tmp="$($2)"
+    echo "add $1 $_tmp"
+}
+
+{
+    add_config cxxflags.mu "pkg-config --cflags poppler-glib icu-uc"
+    add_config ldflags.svgtex "pkg-config --libs poppler-glib"
+    add_config ldflags.mu "pkg-config --libs icu-uc"
 } > $1


### PR DESCRIPTION
It is actually quite tedious to find out a dependecy is missing. Especially when gib reports OK for pkg-config script execution... Well, no more. Gib will now report failiure and approriate error message (the one emmited by pkg-config) will be displayed.